### PR TITLE
Add created_at to posts serializer so we can order posts chronologically

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -13,10 +13,9 @@ class Api::V1::PostsController < ApplicationController
   def circle_posts
     @profile = Profile.find_by(user_id: params[:id])
     return invalid_params if @profile.nil?
-
     @posts = Profile.circle_posts(params[:id])
     @serial = PostSerializer.new(@posts)
-
+    
     render json: @serial
   end
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,4 +1,4 @@
 class PostSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :content, :link, :user_id
+  attributes :content, :link, :user_id, :created_at
 end

--- a/spec/requests/api/v1/posts/circle_posts_get_request_spec.rb
+++ b/spec/requests/api/v1/posts/circle_posts_get_request_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe 'Api::V1::Posts CirclePost', type: :request do
       json = JSON.parse(response.body, symbolize_names: true)
       expect(response.status).to eq(200)
       expect(json[:data].length).to eq(10)
-
       expect(json[:data][0][:type]).to eq('post')
       expect(json[:data][0][:attributes]).to have_key(:content)
       expect(json[:data][0][:attributes]).to have_key(:link)
+      expect(json[:data][0][:attributes]).to have_key(:created_at)
       expect(json[:data][0][:attributes][:user_id]).to eq(@profile_2.user_id)
     end
 


### PR DESCRIPTION
Add created_at to Post serializer, and add happy path test for it.

Co-authored-by: Jesus Quezada-Guillen <17693874+jequeza@users.noreply.github.com>